### PR TITLE
feat: Create new Kinesis Data Firehose delivery stream

### DIFF
--- a/bin/canopy-cli.js
+++ b/bin/canopy-cli.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-
 const cdk = require('aws-cdk-lib');
 const { CdkStack } = require('../lib/cdk-stack');
 
 const app = new cdk.App();
+const envJason = { account: '126159759664', region: 'us-east-2' };
+
 new CdkStack(app, 'FirehoseDeliveryStream', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
@@ -15,7 +16,7 @@ new CdkStack(app, 'FirehoseDeliveryStream', {
 
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
-  // env: { account: '123456789012', region: 'us-east-1' },
+  env: envJason
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });

--- a/lib/cdk-stack.js
+++ b/lib/cdk-stack.js
@@ -1,24 +1,31 @@
 const { Stack, Duration } = require('aws-cdk-lib');
-// const sqs = require('aws-cdk-lib/aws-sqs');
+const kinesis = require('aws-cdk-lib/aws-kinesis');
+const s3  = require('aws-cdk-lib/aws-s3');
+const { FirehoseInfrastructure } = require('./kinesis-firehose-infrastructure');
 
 class CdkStack extends Stack {
-  /**
-   *
-   * @param {Construct} scope
-   * @param {string} id
-   * @param {StackProps=} props
-   */
   constructor(scope, id, props) {
     super(scope, id, props);
 
     this.templateOptions.description = 'Create logging pipeline from CloudFront to Vector';
+
+    // Create a new s3 bucket
+    const bucket = new s3.Bucket(this, 'Bucket', {
+      versioned: true
+    });
 
     // Create a new Kinesis Data stream
     const stream = new kinesis.Stream(this, 'InputStream', {
       streamName: 'cloudfront-real-time-logs-stream',
       streamMode: kinesis.StreamMode.ON_DEMAND
     });
+
+    // Create a new Kinesis Firehose delivery stream
+    new FirehoseInfrastructure(this, 'FirehoseInfrastructure', {
+      bucket: bucket,
+      inputStream: stream
+    });
   }
 }
 
-module.exports = { CanopyCliStack }
+module.exports = { CdkStack }

--- a/lib/kinesis-firehose-infrastructure.js
+++ b/lib/kinesis-firehose-infrastructure.js
@@ -1,0 +1,48 @@
+const { Construct } = require('constructs');
+const kinesisfirehose = require('aws-cdk-lib/aws-kinesisfirehose');
+const { Role, ServicePrincipal } = require('aws-cdk-lib/aws-iam');
+
+class FirehoseInfrastructure extends Construct {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    // Define IAM role for Firehose
+    const firehoseRole = new Role(this, 'firehoseRole', {
+      assumedBy: new ServicePrincipal('firehose.amazonaws.com')
+    });
+
+    // Grant Firehose read access to data stream
+    props.inputStream.grantRead(firehoseRole);
+    props.inputStream.grant(firehoseRole, 'kinesis:DescribeStream');
+
+    // Create new Kinesis Data Firehouse delivery stream
+    const firehoseStreamToVector = new kinesisfirehose.CfnDeliveryStream(this, 'FirehoseStreamToVector', {
+        deliveryStreamName: 'cloudfront-real-time-logs-firehose',
+        deliveryStreamType: 'KinesisStreamAsSource',
+        kinesisStreamSourceConfiguration: {
+          kinesisStreamArn: props.inputStream.streamArn,
+          roleArn: firehoseRole.roleArn,
+        },
+        httpEndpointDestinationConfiguration: {
+          endpointConfiguration: {
+            name: 'HTTP endpoint',
+            url: 'https://vector.amazingjason.dev' // My Vector HTTP endpoint
+          },
+          s3Configuration: {
+            bucketArn: props.bucket.bucketArn,
+            roleArn: firehoseRole.roleArn,
+            errorOutputPrefix: 'failed/'
+          },
+          bufferingHints: {
+            intervalInSeconds: 60, // Default is 300s
+            sizeInMBs: 5,
+          },
+        },
+        roleArn: firehoseRole.roleArn,
+        s3BackupMode: 'FailedDataOnly'
+      }
+    );
+  }
+}
+
+module.exports = { FirehoseInfrastructure };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "canopy-cli",
   "version": "0.1.0",
   "bin": {
-    "canopy-cli": "bin/canopy-cli.js"
+    "cdk": "bin/canopy-cli.js"
   },
   "scripts": {
     "build": "echo \"The build step is not required when using JavaScript!\" && exit 0",


### PR DESCRIPTION
Notes: 
- Extracted out Firehose tasks to its own "class" for readability. It is imported into and invoked as a constructor in the main stack. 
- Created an S3 bucket in the main stack for storage of failed log data. 
- Currently using my Vector HTTP endpoint as the HTTP endpoint destination for the delivery stream.
- Added bufferingHints prop because by default, the interval is 300 seconds. 
- Tested it out using cdk deploy command: Created all the resources (Kinesis Data stream, Firehouse delivery stream, S3 bucket, IAM role)