### PR TITLE
chore: process exits when datasource uid is not found

### DIFF
--- a/src/services/grafana.js
+++ b/src/services/grafana.js
@@ -21,7 +21,8 @@ const getDataSourceUID = () => {
       return result.data.uid;
     })
     .catch((err) => {
-      console.log("There was an error fetching the datasource.")
+      console.log("There was an error fetching the datasource.");
+      process.exit(0);
     });
 }
 


### PR DESCRIPTION
Before, the alert was still being created despite there being no datasource. Now, the process exits with an error message that there is no datasource if that is the case. 