### PR TITLE
simple implementation of launchDashboard command

### DIFF
--- a/src/commands/launchDashboard.js
+++ b/src/commands/launchDashboard.js
@@ -1,0 +1,12 @@
+const { promisify } = require('util');
+const baseExec = require('child_process').exec;
+const exec = promisify(baseExec);
+const path = require('path');
+const pathToDashboard = path.join(__dirname, '../../canopy-admin-dashboard/api')
+
+const launchDashboard = () => {
+  exec(`cd ${pathToDashboard} && npm start`);
+  console.log("In your browser, go to http://localhost:3001 to visit Canopy's Admin Dashboard ");
+}
+
+module.exports = { launchDashboard };

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const { deploy } = require('./commands/deploy');
 const { destroy } = require('./commands/destroy');
 const { configure } = require('./commands/configure');
 const { provisionAlert } = require('./commands/provisionAlert');
+const { launchDashboard } = require('./commands/launchDashboard');
 
 program.description('Canopy Infrastructure Management API');
 program.name('Canopy');
@@ -39,5 +40,10 @@ program
   .option('-3, -alert3', 'Add an alert for bandwidth')
   .option('-4, -alert4', 'Add an alert for the error rate')
   .action(provisionAlert);
+
+program
+  .command('launchDashboard')
+  .description('Launches Canopy Admin Dashboard')
+  .action(launchDashboard);
 
 program.parse(process.argv);


### PR DESCRIPTION
Added a command for the cli, launchDashboard uses exec to start the dashboard api and prints the url to the console for the user. 