### PR TITLE
for the package, when you call the launchDashboard command, now it wi…

### DIFF
--- a/src/commands/launchDashboard.js
+++ b/src/commands/launchDashboard.js
@@ -5,7 +5,7 @@ const path = require('path');
 const pathToDashboard = path.join(__dirname, '../../canopy-admin-dashboard/api')
 
 const launchDashboard = () => {
-  exec(`cd ${pathToDashboard} && npm start`);
+  exec(`cd ${pathToDashboard} && npm install && npm start`);
   console.log("In your browser, go to http://localhost:3001 to visit Canopy's Admin Dashboard ");
 }
 


### PR DESCRIPTION
…ll npm install first, then call the command. This was previously not working when the package was installed. 